### PR TITLE
fix(tmux): fixed tmux.clear_all function

### DIFF
--- a/lua/harpoon/tmux.lua
+++ b/lua/harpoon/tmux.lua
@@ -144,7 +144,7 @@ end
 M.clear_all = function()
     log.trace("tmux: clear_all(): Clearing all tmux windows.")
 
-    for _, window in ipairs(tmux_windows) do
+    for _, window in pairs(tmux_windows) do
         -- Delete the current tmux window
         local _, _, _ = utils.get_os_command_output({
             "tmux",


### PR DESCRIPTION
Using ipairs instead of pairs in this function caused it to stop working
for some use cases.